### PR TITLE
fix(ci): update go-test-coverage from v2.18.0 to v2.18.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           go-version-file: go.mod
       - run: go test ./... -coverprofile=./cover.out
-      - uses: vladopajic/go-test-coverage@d9ec07b8799c458a7bc1f9b36d14261746d63529 # v2.18.0
+      - uses: vladopajic/go-test-coverage@679e6807f68f2440a4c43d386442a1d0041838a9 # v2.18.3
         with:
           profile: cover.out
           local-prefix: github.com/vexxhost/vault-plugin-secrets-openstack


### PR DESCRIPTION
The container image `ghcr.io/vladopajic/go-test-coverage:v2.18.0` has been unavailable since January 6, 2026, causing all CI runs to fail at the Docker pull step.

This updates the action from `v2.18.0` (`d9ec07b8`) to `v2.18.3` (`679e6807`) which has an available container image.

This is a **pre-existing failure** affecting all PRs and pushes to the repo since Jan 6.